### PR TITLE
Revert PSG volume change, filter seems to have lowered the volume a bit

### DIFF
--- a/rtl/audio_cond.sv
+++ b/rtl/audio_cond.sv
@@ -105,7 +105,7 @@ CEGen fltce
 	.CE(ce_flt)
 );
 
-wire [15:0] psg_amp = PSG + PSG[15:1];
+wire [15:0] psg_amp = {PSG[14:0],1'b0};
 
 // 8KHz 2tap
 IIR_filter


### PR DESCRIPTION
I noticed that if we use the older PSG volume, everything lines up now in MDFourier. Here's what it looks like now:
![DA__ALL_AVG_A-MD1UTVA3-M192_vs_NukedMD_Test_0000](https://github.com/MiSTer-devel/MegaDrive_MiSTer/assets/167708/6b564f4f-e1f7-4ee7-8693-9f7cb2d427a8)
