### PR TITLE
add boot1.rom md/genesis rom autoload

### DIFF
--- a/MegaDrive.sv
+++ b/MegaDrive.sv
@@ -432,7 +432,7 @@ hps_io #(.CONF_STR(CONF_STR), .WIDE(1)) hps_io
 wire [1:0] gun_mode = status[41:40];
 wire       gun_btn_mode = status[42];
 
-wire cart_download = ioctl_download & (ioctl_index[4:0] == 1 || ioctl_index[4:0] == 2);
+wire cart_download = ioctl_download & ((ioctl_index[7:6] == 1 &&ioctl_index[5:0] == 0) || ioctl_index[4:0] == 1 || ioctl_index[4:0] == 2);
 wire code_download = ioctl_download & &ioctl_index;
 wire tmss_download = ioctl_download & !ioctl_index;
 


### PR DESCRIPTION
Only works for Genesis games, SMS games currently not autodetected outside of their filename extension from FS2 index anyways.

Test core --> [MegaDrive.zip](https://github.com/MiSTer-devel/MegaDrive_MiSTer/files/12707341/MegaDrive.zip)

Resolves issue mentioned here --> https://github.com/uberyoji/mister-boot-roms/issues/6#issuecomment-1730777196 - (and multiple users on discord asked about it a few times)