### PR TITLE
Fix Sonic 3 saves not loading on cold boot

### DIFF
--- a/MegaDrive.sv
+++ b/MegaDrive.sv
@@ -469,7 +469,7 @@ end
 
 ///////////////////////////////////////////////////
 
-wire reset = RESET | status[0] | buttons[1] | region_set_rst;
+wire reset = RESET | status[0] | buttons[1] | region_set_rst | bk_loading;
 
 reg sys_reset;
 always @(posedge clk_sys) sys_reset <= reset|cart_download;


### PR DESCRIPTION
Discord user Shan found this bug where upon a cold boot of the MiSTer, Sonic 3 (any variant) would not load the present game save until a reset of the game. Most other games are probably not as sensitive as Sonic 3 is to the game load + sram load timing.

Pretty much every core ties the bk_loading signal to the RESET signal in the emu module this way so I tried this fix and it worked in my testing.