### PR TITLE
Remove logic ramstyle attributes from vm2413

### DIFF
--- a/rtl/VM2413/feedbackmemory.vhd
+++ b/rtl/VM2413/feedbackmemory.vhd
@@ -53,8 +53,6 @@ architecture RTL of FeedbackMemory is
 
   type SIGNED_LI_ARRAY_TYPE is array (0 to 9-1) of SIGNED_LI_VECTOR_TYPE;
   signal data_array : SIGNED_LI_ARRAY_TYPE;
-  attribute ramstyle : string;
-  attribute ramstyle of data_array : signal is "logic";
 
 begin
 

--- a/rtl/VM2413/outputmemory.vhd
+++ b/rtl/VM2413/outputmemory.vhd
@@ -49,8 +49,6 @@ architecture RTL of OutputMemory is
 
   type SIGNED_LI_ARRAY_TYPE is array (0 to 18) of SIGNED_LI_VECTOR_TYPE;
   signal data_array : SIGNED_LI_ARRAY_TYPE;
-  attribute ramstyle : string;
-  attribute ramstyle of data_array : signal is "logic";
 
 begin
 

--- a/rtl/VM2413/phasememory.vhd
+++ b/rtl/VM2413/phasememory.vhd
@@ -48,8 +48,6 @@ architecture RTL of PhaseMemory is
 
   type PHASE_ARRAY_TYPE is array (0 to 18-1) of PHASE_TYPE;
   signal phase_array : PHASE_ARRAY_TYPE;
-  attribute ramstyle : string;
-  attribute ramstyle of phase_array : signal is "logic";
 
 begin
 


### PR DESCRIPTION
These were originally added for the SMS core by gyurco to help the core fit on MiST's Cyclone III chip which has significantly less BRAM. I kept the module registermemory.vhd asserted into logic as this actually caused timing issues for it the ramstyle to be removed (it asserts into M10k when left to automatically infer, which is slower than logic in most cases). The other 3 modules changed inferred to MLAB automatically, which is somewhat faster than logic usually.

ALMS reduced from 34,003 to 33,834. Registers used reduced from 52178 to 51469. RAM blocks used increased from 438 to 442 (out of 553 total). No significant timing analysis differences were observed as a result of this change.