### PR TITLE
Add MD+ support

### DIFF
--- a/MegaDrive.sv
+++ b/MegaDrive.sv
@@ -178,11 +178,21 @@ assign ADC_BUS  = 'Z;
 assign {UART_RTS, UART_TXD, UART_DTR} = 0;
 assign BUTTONS   = osd_btn;
 assign {SD_SCK, SD_MOSI, SD_CS} = 'Z;
-assign {DDRAM_CLK, DDRAM_BURSTCNT, DDRAM_ADDR, DDRAM_DIN, DDRAM_BE, DDRAM_RD, DDRAM_WE} = '0;  
+// DDRAM driven by mdp_audio for CDDA PCM streaming
 
 assign LED_DISK  = 0;
 assign LED_POWER = 0;
-assign LED_USER  = cart_download | sav_pending;
+
+// MD+ debug: sticky latch — LED stays on after first MD+ command received
+reg mdp_cmd_seen;
+always @(posedge clk_sys) begin
+	if (sys_reset)
+		mdp_cmd_seen <= 0;
+	else if (mdp_track_request | mdp_stop_request | mdp_resume_request)
+		mdp_cmd_seen <= 1;
+end
+
+assign LED_USER  = cart_download | sav_pending | mdp_cmd_seen;
 
 assign VGA_SCALER= 0;
 assign VGA_DISABLE = 0;
@@ -389,6 +399,8 @@ wire [24:0] ps2_mouse;
 wire [21:0] gamma_bus;
 wire [15:0] sdram_sz;
 
+wire [35:0] EXT_BUS;
+
 hps_io #(.CONF_STR(CONF_STR), .WIDE(1)) hps_io
 (
 	.clk_sys(clk_sys),
@@ -436,7 +448,9 @@ hps_io #(.CONF_STR(CONF_STR), .WIDE(1)) hps_io
 	.ps2_key(ps2_key),
 	.ps2_kbd_led_status(ps2_kbd_led_status),
 	.ps2_kbd_led_use(ps2_kbd_led_use),
-	.ps2_mouse(ps2_mouse)
+	.ps2_mouse(ps2_mouse),
+
+	.EXT_BUS(EXT_BUS)
 );
 
 wire [1:0] gun_mode = status[41:40];
@@ -547,10 +561,34 @@ end
 wire        PAL = status[7];
 wire        JAP = !status[7:6];
 
-wire [15:0] cart_data;
 wire [23:1] cart_addr;
-wire        cart_cs, cart_oe, cart_lwr, cart_uwr, cart_data_en, cart_dtack, cart_time, cart_dma;
+wire        cart_cs, cart_oe, cart_lwr, cart_uwr, cart_time, cart_dma;
 wire [15:0] cart_data_wr;
+
+// Cartridge module outputs (before MD+ overlay mux)
+wire [15:0] cart_data_rom;
+wire        cart_data_en_rom;
+wire        cart_dtack_rom;
+
+// MD+ overlay outputs
+wire        mdp_data_en;
+wire [15:0] mdp_data_out;
+wire        mdp_dtack;
+wire        mdp_active;
+wire [15:0] mdp_last_cmd;
+wire        mdp_track_request;
+wire  [7:0] mdp_track_num;
+wire        mdp_track_loop;
+wire        mdp_stop_request;
+wire  [7:0] mdp_fade_sectors;
+wire        mdp_resume_request;
+wire  [7:0] mdp_volume;
+wire        mdp_volume_request;
+
+// Muxed cart signals: MD+ overlay takes priority when active
+wire [15:0] cart_data    = mdp_data_en ? mdp_data_out : cart_data_rom;
+wire        cart_data_en = mdp_data_en | cart_data_en_rom;
+wire        cart_dtack   = mdp_dtack   | cart_dtack_rom;
 
 wire        vdp_hclk1;
 wire        vdp_de_h;
@@ -770,15 +808,15 @@ cartridge cartridge
 
 	.cart_ms(cart_ms),
 	.cart_addr(cart_addr),
-	.cart_data(cart_data),
-	.cart_data_en(cart_data_en),
+	.cart_data(cart_data_rom),
+	.cart_data_en(cart_data_en_rom),
 	.cart_data_wr(cart_data_wr),
 	.cart_cs(cart_cs),
 	.cart_oe(cart_oe),
 	.cart_lwr(cart_lwr),
 	.cart_uwr(cart_uwr),
 	.cart_time(cart_time),
-	.cart_dtack(cart_dtack),
+	.cart_dtack(cart_dtack_rom),
 	.cart_dma(cart_dma),
 
 	.save_addr({sd_lba[6:0],sd_buff_addr}),
@@ -798,6 +836,111 @@ cartridge cartridge
 
 	.fm_en(~status[60]),
 	.fm_audio(sms_fm_audio)
+);
+
+
+///////////////////////////////////////////////////
+// MD+ Overlay (CDDA command intercept)
+///////////////////////////////////////////////////
+
+// HPS ↔ FPGA bridge for MD+ status + audio pointer exchange
+wire mdp_hps_playing;
+wire [7:0] mdp_hps_current_track;
+wire [15:0] mdp_audio_rd_ptr;
+wire [15:0] mdp_audio_wr_ptr;
+wire        mdp_audio_active;
+
+hps_ext hps_ext
+(
+	.clk_sys(clk_sys),
+	.reset(sys_reset),
+	.EXT_BUS(EXT_BUS),
+
+	.mdp_track_request(mdp_track_request),
+	.mdp_track_num(mdp_track_num),
+	.mdp_track_loop(mdp_track_loop),
+	.mdp_stop_request(mdp_stop_request),
+	.mdp_fade_sectors(mdp_fade_sectors),
+	.mdp_resume_request(mdp_resume_request),
+	.mdp_volume(mdp_volume),
+	.mdp_volume_request(mdp_volume_request),
+
+	.mdp_playing(mdp_hps_playing),
+	.mdp_current_track(mdp_hps_current_track),
+
+	.audio_rd_ptr(mdp_audio_rd_ptr),
+	.audio_wr_ptr(mdp_audio_wr_ptr),
+	.audio_active(mdp_audio_active)
+);
+
+md_plus md_plus
+(
+	.clk(clk_sys),
+	.reset(sys_reset),
+
+	.cart_addr(cart_addr),
+	.cart_data_wr(cart_data_wr),
+	.cart_cs(cart_cs),
+	.cart_oe(cart_oe),
+	.cart_lwr(cart_lwr),
+	.cart_uwr(cart_uwr),
+
+	.mdp_data_en(mdp_data_en),
+	.mdp_data_out(mdp_data_out),
+	.mdp_dtack(mdp_dtack),
+
+	.mdp_track_request(mdp_track_request),
+	.mdp_track_num(mdp_track_num),
+	.mdp_track_loop(mdp_track_loop),
+	.mdp_stop_request(mdp_stop_request),
+	.mdp_fade_sectors(mdp_fade_sectors),
+	.mdp_resume_request(mdp_resume_request),
+	.mdp_volume(mdp_volume),
+	.mdp_volume_request(mdp_volume_request),
+
+	.mdp_playing(mdp_hps_playing),
+	.mdp_current_track(mdp_hps_current_track),
+
+	.mdp_active(mdp_active),
+	.mdp_last_cmd(mdp_last_cmd)
+);
+
+// CDDA audio output from mdp_audio
+wire signed [15:0] cdda_l, cdda_r;
+
+mdp_audio mdp_audio
+(
+	.clk(clk_sys),
+	.reset(sys_reset),
+
+	// DDRAM interface
+	.DDRAM_CLK(DDRAM_CLK),
+	.DDRAM_BUSY(DDRAM_BUSY),
+	.DDRAM_BURSTCNT(DDRAM_BURSTCNT),
+	.DDRAM_ADDR(DDRAM_ADDR),
+	.DDRAM_DOUT(DDRAM_DOUT),
+	.DDRAM_DOUT_READY(DDRAM_DOUT_READY),
+	.DDRAM_RD(DDRAM_RD),
+	.DDRAM_DIN(DDRAM_DIN),
+	.DDRAM_BE(DDRAM_BE),
+	.DDRAM_WE(DDRAM_WE),
+
+	// Ring buffer pointers (from/to hps_ext)
+	.active(mdp_audio_active),
+	.buf_wr_ptr(mdp_audio_wr_ptr),
+	.buf_rd_ptr(mdp_audio_rd_ptr),
+
+	// MD+ commands (directly from md_plus)
+	.track_start(mdp_track_request),
+	.stop_request(mdp_stop_request),
+	.fade_sectors(mdp_fade_sectors),
+	.volume(mdp_volume),
+	.resume_request(mdp_resume_request),
+	.osd_pause(OSD_STATUS & status[61]),
+
+	// Audio output
+	.audio_l(cdda_l),
+	.audio_r(cdda_r)
 );
 
 
@@ -895,6 +1038,9 @@ video_mixer #(.LINE_LENGTH(400), .GAMMA(1)) video_mixer
 
 ///////////////////////////////////////////////////
 
+// FM + PSG base audio (before CDDA mix)
+wire [15:0] base_audio_l, base_audio_r;
+
 audio_cond audio_cond
 (
 	.clk(clk_sys),
@@ -913,9 +1059,22 @@ audio_cond audio_cond
 	.PSG(PSG),
 	.sms_fm_audio(sms_fm_audio),
 
-	.AUDIO_L(AUDIO_L),
-	.AUDIO_R(AUDIO_R)
+	.AUDIO_L(base_audio_l),
+	.AUDIO_R(base_audio_r)
 );
+
+// Attenuate CDDA: 93/256 ≈ 0.363 — matched to Mega Drive hardware output via A/B recording comparisons
+wire signed [24:0] cdda_scaled_l = $signed(cdda_l) * $signed(9'd93);
+wire signed [24:0] cdda_scaled_r = $signed(cdda_r) * $signed(9'd93);
+wire signed [15:0] cdda_att_l = cdda_scaled_l[23:8];
+wire signed [15:0] cdda_att_r = cdda_scaled_r[23:8];
+
+// Saturating mix: FM/PSG + attenuated CDDA
+wire signed [16:0] mix_l = $signed(base_audio_l) + $signed(cdda_att_l);
+wire signed [16:0] mix_r = $signed(base_audio_r) + $signed(cdda_att_r);
+
+assign AUDIO_L = (mix_l[16] != mix_l[15]) ? {mix_l[16], {15{~mix_l[16]}}} : mix_l[15:0];
+assign AUDIO_R = (mix_r[16] != mix_r[15]) ? {mix_r[16], {15{~mix_r[16]}}} : mix_r[15:0];
 
 assign AUDIO_MIX = status[58:57];
 

--- a/files.qip
+++ b/files.qip
@@ -20,6 +20,9 @@ set_global_assignment -name SYSTEMVERILOG_FILE rtl/teamplayer.sv
 set_global_assignment -name SYSTEMVERILOG_FILE rtl/fourway.sv
 set_global_assignment -name SYSTEMVERILOG_FILE rtl/md_io.sv
 set_global_assignment -name SYSTEMVERILOG_FILE rtl/cartridge.sv
+set_global_assignment -name SYSTEMVERILOG_FILE rtl/md_plus.sv
+set_global_assignment -name SYSTEMVERILOG_FILE rtl/mdp_audio.sv
+set_global_assignment -name SYSTEMVERILOG_FILE hps_ext.sv
 set_global_assignment -name SYSTEMVERILOG_FILE rtl/saturn_keyboard.sv
 set_global_assignment -name SDC_FILE MegaDrive.sdc
 set_global_assignment -name SYSTEMVERILOG_FILE MegaDrive.sv

--- a/hps_ext.sv
+++ b/hps_ext.sv
@@ -1,0 +1,173 @@
+// MD+ HPS Extension interface
+// Bridges EXT_BUS between hps_io and the MD+ overlay module.
+//
+// Commands:
+//   CMD_MDP_STATUS (0x60): HPS reads MD+ command state
+//     Resp 0: {track_num[7:0], cmd_flags[7:0]}
+//     Resp 1: {fade_sectors[7:0], volume[7:0]}
+//
+//   CMD_MDP_ACK (0x61): HPS acknowledges + sends status back
+//     HPS word 1: {current_track[7:0], 7'b0, playing}
+//     Clears all pending command flags.
+//
+//   CMD_MDP_AUDIO (0x62): Audio buffer pointer exchange
+//     Resp 0: audio_rd_ptr[15:0]  (FPGA read pointer)
+//     HPS word 1: audio_wr_ptr[15:0]  (HPS write pointer)
+
+module hps_ext
+(
+	input             clk_sys,
+	input             reset,
+	inout      [35:0] EXT_BUS,
+
+	input             mdp_track_request,
+	input       [7:0] mdp_track_num,
+	input             mdp_track_loop,
+	input             mdp_stop_request,
+	input       [7:0] mdp_fade_sectors,
+	input             mdp_resume_request,
+	input       [7:0] mdp_volume,
+	input             mdp_volume_request,
+
+	output reg        mdp_playing,
+	output reg  [7:0] mdp_current_track,
+
+	input      [15:0] audio_rd_ptr,
+	output reg [15:0] audio_wr_ptr,
+	output reg        audio_active
+);
+
+// EXT_BUS signal mapping
+assign EXT_BUS[15:0] = io_dout;
+assign EXT_BUS[32]   = dout_en;
+
+wire [15:0] io_din    = EXT_BUS[31:16];
+wire        io_strobe = EXT_BUS[33];
+wire        io_enable = EXT_BUS[34];
+
+localparam CMD_MDP_STATUS = 8'h60;
+localparam CMD_MDP_ACK    = 8'h61;
+localparam CMD_MDP_AUDIO  = 8'h62;
+localparam CMD_MDP_MIN    = CMD_MDP_STATUS;
+localparam CMD_MDP_MAX    = CMD_MDP_AUDIO;
+
+// Pending command latches (sticky until HPS ACKs)
+reg       pending_play;
+reg       pending_stop;
+reg       pending_resume;
+reg       pending_volume;
+reg [7:0] latched_track_num;
+reg       latched_track_loop;
+reg [7:0] latched_fade_sectors;
+reg [7:0] latched_volume;
+
+wire [7:0] cmd_byte = {3'b0, latched_track_loop, pending_volume,
+                       pending_resume, pending_stop, pending_play};
+
+// EXT_BUS command processing
+reg [15:0] io_dout;
+reg        dout_en;
+reg  [7:0] cmd;
+reg  [3:0] byte_cnt;
+reg        old_strobe;
+
+always @(posedge clk_sys) begin
+	if (reset) begin
+		pending_play         <= 0;
+		pending_stop         <= 0;
+		pending_resume       <= 0;
+		pending_volume       <= 0;
+		latched_track_num    <= 0;
+		latched_track_loop   <= 0;
+		latched_fade_sectors <= 0;
+		latched_volume       <= 8'hFF;
+		mdp_playing          <= 0;
+		mdp_current_track    <= 0;
+		audio_wr_ptr         <= 0;
+		audio_active         <= 0;
+		dout_en              <= 0;
+		cmd                  <= 0;
+		byte_cnt             <= 0;
+	end
+	else begin
+		// Latch md_plus pulses (sticky until ACK clears them)
+		if (mdp_track_request) begin
+			pending_play       <= 1;
+			latched_track_num  <= mdp_track_num;
+			latched_track_loop <= mdp_track_loop;
+		end
+		if (mdp_stop_request) begin
+			pending_stop         <= 1;
+			latched_fade_sectors <= mdp_fade_sectors;
+		end
+		if (mdp_resume_request)
+			pending_resume <= 1;
+		if (mdp_volume_request) begin
+			pending_volume <= 1;
+			latched_volume <= mdp_volume;
+		end
+
+		old_strobe <= io_strobe;
+
+		if (~io_enable) begin
+			dout_en  <= 0;
+			byte_cnt <= 0;
+			cmd      <= 0;
+		end
+		else if (io_strobe & ~old_strobe) begin
+			if (~|byte_cnt) begin
+				cmd     <= io_din[7:0];
+				dout_en <= (io_din[7:0] >= CMD_MDP_MIN) &&
+				           (io_din[7:0] <= CMD_MDP_MAX);
+
+				case (io_din[7:0])
+					CMD_MDP_STATUS:
+						io_dout <= {latched_track_num, cmd_byte};
+					CMD_MDP_AUDIO:
+						io_dout <= audio_rd_ptr;
+					default:
+						io_dout <= 16'h0000;
+				endcase
+
+				byte_cnt <= 1;
+			end
+			else begin
+				byte_cnt <= byte_cnt + 1'd1;
+
+				case (cmd)
+					CMD_MDP_STATUS: begin
+						if (byte_cnt == 4'd1)
+							io_dout <= {latched_fade_sectors, latched_volume};
+						else
+							io_dout <= 16'h0000;
+					end
+
+					CMD_MDP_ACK: begin
+						if (byte_cnt == 4'd1) begin
+							mdp_current_track <= io_din[15:8];
+							mdp_playing       <= io_din[0];
+							audio_active      <= io_din[0];
+							pending_play      <= 0;
+							pending_stop      <= 0;
+							pending_resume    <= 0;
+							pending_volume    <= 0;
+						end
+						io_dout <= 16'h0000;
+					end
+
+					CMD_MDP_AUDIO: begin
+						if (byte_cnt == 4'd1) begin
+							audio_wr_ptr <= io_din;
+						end
+						io_dout <= 16'h0000;
+					end
+
+					default:
+						io_dout <= 16'hFFFF;
+				endcase
+			end
+		end
+	end
+end
+
+endmodule

--- a/rtl/md_plus.sv
+++ b/rtl/md_plus.sv
@@ -1,0 +1,206 @@
+// MD+ CDDA Overlay support for MiSTer MegaDrive core
+//
+// Intercepts 68K bus writes to the MD+ overlay region ($3F7F6-$3FFFF)
+// and decodes MD+ CDDA commands.
+//
+// MD+ Protocol:
+//   Open overlay:  write $CD54 to $3F7FA (word)
+//   Command port:  write to $3F7FE (word) - high byte = cmd, low byte = param
+//   Result port:   read $3F7FC (word)
+//   Close overlay: write anything != $CD54 to $3F7FA
+//   ID ports:      $3F7F6 = $4241 ("BA"), $3F7F8 = $5445 ("TE")
+//
+// Commands:
+//   $11XX - play track XX once
+//   $12XX - play track XX and loop
+//   $13XX - stop/fade (XX=0: immediate, XX>0: fade over XX sectors @ 75/sec)
+//   $1400 - resume after pause
+//   $15XX - set volume (XX = 0-255)
+//   $17XX - read sector (data commands, not needed for audio)
+//   $18XX - transfer sector
+//   $19XX - read next sector
+
+module md_plus
+(
+    input             clk,
+    input             reset,
+
+    input      [23:1] cart_addr,
+    input      [15:0] cart_data_wr,
+    input             cart_cs,
+    input             cart_oe,
+    input             cart_lwr,
+    input             cart_uwr,
+
+    output reg        mdp_data_en,
+    output reg [15:0] mdp_data_out,
+    output            mdp_dtack,
+
+    output reg        mdp_track_request,
+    output reg  [7:0] mdp_track_num,
+    output reg        mdp_track_loop,
+    output reg        mdp_stop_request,
+    output reg  [7:0] mdp_fade_sectors,
+    output reg        mdp_resume_request,
+    output reg  [7:0] mdp_volume,
+    output reg        mdp_volume_request,
+
+    input             mdp_playing,
+    input       [7:0] mdp_current_track,
+
+    output reg        mdp_active,
+    output reg [15:0] mdp_last_cmd
+);
+
+// Address decode
+// Word addresses (cart_addr is [23:1], so byte addr = {cart_addr, 1'b0})
+
+localparam [23:1] ADDR_ID0     = 23'h1FBFB;  // $3F7F6
+localparam [23:1] ADDR_ID1     = 23'h1FBFC;  // $3F7F8
+localparam [23:1] ADDR_CONTROL = 23'h1FBFD;  // $3F7FA
+localparam [23:1] ADDR_RESULT  = 23'h1FBFE;  // $3F7FC
+localparam [23:1] ADDR_COMMAND = 23'h1FBFF;  // $3F7FE
+
+localparam [15:0] OVERLAY_MAGIC = 16'hCD54;
+localparam [15:0] ID_PORT_0     = 16'h4241;  // "BA"
+localparam [15:0] ID_PORT_1     = 16'h5445;  // "TE"
+
+// Overlay state
+
+reg overlay_open;
+reg cmd_written;
+
+wire addr_in_overlay = (cart_addr >= ADDR_ID0) && (cart_addr <= ADDR_COMMAND);
+wire is_write = cart_lwr | cart_uwr;
+wire is_read  = cart_oe;
+
+// Edge detect to avoid re-triggering on held writes
+reg old_write;
+wire write_pulse = is_write & addr_in_overlay & ~old_write;
+
+always @(posedge clk) begin
+    old_write <= is_write & addr_in_overlay;
+end
+
+// Command processing
+
+always @(posedge clk) begin
+    if (reset) begin
+        overlay_open        <= 0;
+        mdp_active          <= 0;
+        mdp_track_request   <= 0;
+        mdp_stop_request    <= 0;
+        mdp_resume_request  <= 0;
+        mdp_volume_request  <= 0;
+        mdp_volume          <= 8'hFF;
+        mdp_track_num       <= 0;
+        mdp_track_loop      <= 0;
+        mdp_fade_sectors    <= 0;
+        mdp_last_cmd        <= 0;
+        cmd_written         <= 0;
+    end
+    else begin
+        mdp_track_request   <= 0;
+        mdp_stop_request    <= 0;
+        mdp_resume_request  <= 0;
+        mdp_volume_request  <= 0;
+
+        // Neodev patches poll command port high byte for $00 to confirm
+        // command completion. We dispatch instantly, so clear on next cycle.
+        if (cmd_written) begin
+            mdp_last_cmd <= 0;
+            cmd_written  <= 0;
+        end
+
+        if (write_pulse) begin
+            case (cart_addr)
+                ADDR_CONTROL: begin
+                    if (cart_data_wr == OVERLAY_MAGIC)
+                        overlay_open <= 1;
+                    else
+                        overlay_open <= 0;
+                end
+
+                ADDR_COMMAND: begin
+                    if (overlay_open) begin
+                        mdp_last_cmd <= cart_data_wr;
+                        cmd_written  <= 1;
+
+                        case (cart_data_wr[15:8])
+                            8'h11: begin
+                                mdp_track_num     <= cart_data_wr[7:0];
+                                mdp_track_loop    <= 0;
+                                mdp_track_request <= 1;
+                            end
+                            8'h12: begin
+                                mdp_track_num     <= cart_data_wr[7:0];
+                                mdp_track_loop    <= 1;
+                                mdp_track_request <= 1;
+                            end
+                            8'h13: begin
+                                mdp_fade_sectors   <= cart_data_wr[7:0];
+                                mdp_stop_request   <= 1;
+                            end
+                            8'h14: begin
+                                mdp_resume_request <= 1;
+                            end
+                            8'h15: begin
+                                mdp_volume         <= cart_data_wr[7:0];
+                                mdp_volume_request <= 1;
+                            end
+                            default: ;
+                        endcase
+                    end
+                end
+
+                default: ;
+            endcase
+        end
+
+        mdp_active <= overlay_open;
+    end
+end
+
+// Read data mux
+
+always @(posedge clk) begin
+    mdp_data_en  <= 0;
+    mdp_data_out <= 16'hFFFF;
+
+    if (is_read & addr_in_overlay & overlay_open) begin
+        case (cart_addr)
+            ADDR_ID0: begin
+                mdp_data_en  <= 1;
+                mdp_data_out <= ID_PORT_0;
+            end
+            ADDR_ID1: begin
+                mdp_data_en  <= 1;
+                mdp_data_out <= ID_PORT_1;
+            end
+            ADDR_RESULT: begin
+                mdp_data_en  <= 1;
+                // {current_track[7:0], 7'b0, playing}
+                mdp_data_out <= {mdp_current_track, 7'b0, mdp_playing};
+            end
+            ADDR_CONTROL: begin
+                mdp_data_en  <= 1;
+                mdp_data_out <= overlay_open ? OVERLAY_MAGIC : 16'h0000;
+            end
+            ADDR_COMMAND: begin
+                mdp_data_en  <= 1;
+                mdp_data_out <= mdp_last_cmd;
+            end
+            default: begin
+                // Data area $3F800-$3FFFF — return zeros for now
+                if (cart_addr > ADDR_COMMAND) begin
+                    mdp_data_en  <= 1;
+                    mdp_data_out <= 16'h0000;
+                end
+            end
+        endcase
+    end
+end
+
+assign mdp_dtack = mdp_data_en;
+
+endmodule

--- a/rtl/mdp_audio.sv
+++ b/rtl/mdp_audio.sv
@@ -1,0 +1,263 @@
+// MD+ Audio Streaming Module
+//
+// Reads 16-bit stereo 44.1kHz PCM from a ring buffer in DDRAM (written by
+// the HPS), applies volume and hardware fade, and outputs audio samples.
+//
+// DDRAM ring buffer: 64KB at configurable base address.
+// HPS writes WAV PCM data into the buffer and updates the write pointer
+// via EXT_BUS. FPGA reads at 44.1kHz and reports its read pointer back.
+//
+// Sample format in DDRAM (little-endian, matches WAV):
+//   Each 64-bit word = 2 stereo samples
+//   Bits [15:0]  = Sample 0 Left
+//   Bits [31:16] = Sample 0 Right
+//   Bits [47:32] = Sample 1 Left
+//   Bits [63:48] = Sample 1 Right
+
+module mdp_audio
+(
+	input             clk,
+	input             reset,
+
+	output            DDRAM_CLK,
+	input             DDRAM_BUSY,
+	output reg  [7:0] DDRAM_BURSTCNT,
+	output reg [28:0] DDRAM_ADDR,
+	input      [63:0] DDRAM_DOUT,
+	input             DDRAM_DOUT_READY,
+	output reg        DDRAM_RD,
+	output     [63:0] DDRAM_DIN,
+	output      [7:0] DDRAM_BE,
+	output            DDRAM_WE,
+
+	input             active,
+	input      [15:0] buf_wr_ptr,
+	output     [15:0] buf_rd_ptr,
+
+	input             track_start,
+	input             stop_request,
+	input       [7:0] fade_sectors,
+	input       [7:0] volume,
+	input             resume_request,
+	input             osd_pause,
+
+	output reg signed [15:0] audio_l,
+	output reg signed [15:0] audio_r
+);
+
+assign DDRAM_CLK = clk;
+// Read-only DDRAM access
+assign DDRAM_DIN = 64'd0;
+assign DDRAM_BE  = 8'hFF;
+assign DDRAM_WE  = 1'b0;
+
+// Ring buffer: 64KB, byte address 0x30000000 -> DDRAM_ADDR = 0x30000000 >> 3
+localparam [28:0] DDRAM_BASE = 29'h6000000;
+localparam [15:0] BUF_MASK   = 16'hFFFF;
+
+// Internal FIFO (256 stereo samples in M10K BRAM)
+(* ramstyle = "M10K" *) reg [31:0] fifo_mem [0:255];
+
+reg  [7:0] fifo_wr;
+reg  [7:0] fifo_rd;
+wire [8:0] fifo_used  = {1'b0, fifo_wr} - {1'b0, fifo_rd};
+wire       fifo_low   = (fifo_used < 9'd128);
+wire       fifo_full  = (fifo_used >= 9'd254);
+wire       fifo_empty = (fifo_wr == fifo_rd);
+
+reg [31:0] fifo_rdata;
+always @(posedge clk) fifo_rdata <= fifo_mem[fifo_rd];
+
+// Read pointer
+reg [15:0] rd_ptr;
+assign buf_rd_ptr = rd_ptr;
+
+wire [16:0] buf_avail = {1'b0, buf_wr_ptr} - {1'b0, rd_ptr};
+wire        buf_has_data = (buf_avail[15:0] >= 16'd8);
+
+// Pause state
+reg paused;
+
+always @(posedge clk) begin
+	if (reset) begin
+		paused <= 0;
+	end else begin
+		if (track_start)
+			paused <= 0;
+		else if (stop_request && fade_sectors == 0)
+			paused <= 1;
+		else if (resume_request)
+			paused <= 0;
+	end
+end
+
+// Track-start mute: suppress output for ~50ms to let HPS pre-fill
+// 50ms at 53.7MHz = ~2,685,000 clocks
+reg [21:0] mute_ctr;
+wire       muted = |mute_ctr;
+
+always @(posedge clk) begin
+	if (reset)
+		mute_ctr <= 0;
+	else if (track_start)
+		mute_ctr <= 22'd2685000;
+	else if (mute_ctr > 0)
+		mute_ctr <= mute_ctr - 1'd1;
+end
+
+// Fade engine
+// $13XX fades over XX sectors at 75 sectors/sec.
+// Ramps fade_vol 255->0 in 255 steps.
+// Step duration = (sectors/75) * clk_freq / 255 = ~sectors * 2808 clocks.
+reg  [7:0] fade_vol;
+reg        fading;
+reg [19:0] fade_timer;
+reg [19:0] fade_step;
+
+always @(posedge clk) begin
+	if (reset) begin
+		fade_vol  <= 8'hFF;
+		fading    <= 0;
+	end else begin
+		if (track_start) begin
+			fade_vol <= 8'hFF;
+			fading   <= 0;
+		end
+		else if (stop_request) begin
+			if (fade_sectors == 0) begin
+				fade_vol <= 8'hFF;
+				fading   <= 0;
+			end else begin
+				fading    <= 1;
+				fade_step <= {12'd0, fade_sectors} * 20'd2808;
+				fade_timer<= 0;
+			end
+		end
+		else if (fading) begin
+			if (fade_timer >= fade_step) begin
+				fade_timer <= 0;
+				if (fade_vol == 0)
+					fading <= 0;
+				else
+					fade_vol <= fade_vol - 1'd1;
+			end else begin
+				fade_timer <= fade_timer + 1'd1;
+			end
+		end
+	end
+end
+
+// eff_volume = (game_volume * fade_vol) >> 8
+wire [15:0] vol_product = {8'd0, volume} * {8'd0, fade_vol};
+wire  [7:0] eff_volume  = vol_product[15:8];
+
+// 44.1 kHz sample clock (~53.7 MHz / 1218 = ~44083 Hz)
+reg [10:0] sample_div;
+reg        sample_tick;
+
+always @(posedge clk) begin
+	sample_tick <= 0;
+	if (reset)
+		sample_div <= 0;
+	else if (sample_div >= 11'd1217) begin
+		sample_div  <= 0;
+		sample_tick <= 1;
+	end else
+		sample_div <= sample_div + 1'd1;
+end
+
+// DDRAM read state machine
+localparam [2:0] DDR_IDLE    = 3'd0,
+                 DDR_REQ     = 3'd1,
+                 DDR_WAIT    = 3'd2,
+                 DDR_STORE0  = 3'd3,
+                 DDR_STORE1  = 3'd4;
+
+reg  [2:0] ddr_state;
+reg [63:0] ddr_latch;
+
+always @(posedge clk) begin
+	if (reset) begin
+		ddr_state  <= DDR_IDLE;
+		DDRAM_RD   <= 0;
+		rd_ptr     <= 0;
+		fifo_wr    <= 0;
+	end else begin
+		DDRAM_RD <= 0;
+
+		case (ddr_state)
+			DDR_IDLE: begin
+				if (active && !paused && !osd_pause && !muted && fifo_low && buf_has_data)
+					ddr_state <= DDR_REQ;
+			end
+
+			DDR_REQ: begin
+				if (!DDRAM_BUSY) begin
+					DDRAM_ADDR     <= DDRAM_BASE + {16'd0, rd_ptr[15:3]};
+					DDRAM_BURSTCNT <= 8'd1;
+					DDRAM_RD       <= 1;
+					ddr_state      <= DDR_WAIT;
+				end
+			end
+
+			DDR_WAIT: begin
+				if (DDRAM_DOUT_READY) begin
+					ddr_latch <= DDRAM_DOUT;
+					if (!fifo_full) begin
+						fifo_mem[fifo_wr] <= DDRAM_DOUT[31:0];
+						fifo_wr <= fifo_wr + 1'd1;
+					end
+					ddr_state <= DDR_STORE1;
+				end
+			end
+
+			DDR_STORE1: begin
+				if (!fifo_full) begin
+					fifo_mem[fifo_wr] <= ddr_latch[63:32];
+					fifo_wr <= fifo_wr + 1'd1;
+				end
+				// 8 bytes = one 64-bit word consumed
+				rd_ptr    <= (rd_ptr + 16'd8) & BUF_MASK;
+				ddr_state <= DDR_IDLE;
+			end
+
+			default: ddr_state <= DDR_IDLE;
+		endcase
+
+		if (track_start) begin
+			fifo_wr   <= 0;
+			rd_ptr    <= 0;
+			ddr_state <= DDR_IDLE;
+			DDRAM_RD  <= 0;
+		end
+	end
+end
+
+// Audio output: volume-scaled at 44.1kHz sample rate
+wire signed [15:0] raw_l = $signed(fifo_rdata[15:0]);
+wire signed [15:0] raw_r = $signed(fifo_rdata[31:16]);
+
+wire signed [24:0] scaled_l = raw_l * $signed({1'b0, eff_volume});
+wire signed [24:0] scaled_r = raw_r * $signed({1'b0, eff_volume});
+
+always @(posedge clk) begin
+	if (reset) begin
+		audio_l <= 0;
+		audio_r <= 0;
+		fifo_rd <= 0;
+	end else if (sample_tick) begin
+		if (active && !paused && !osd_pause && !muted && !fifo_empty && fade_vol > 0) begin
+			fifo_rd <= fifo_rd + 1'd1;
+			audio_l <= scaled_l[23:8];
+			audio_r <= scaled_r[23:8];
+		end else begin
+			audio_l <= 0;
+			audio_r <= 0;
+		end
+	end
+
+	if (track_start)
+		fifo_rd <= 0;
+end
+
+endmodule


### PR DESCRIPTION
This commit adds MD+ support to the MegaDrive core.

MD+ is a standard for playing CD quality audio alongside cartridge games. The patched ROM sends commands to an overlay region, and the core plays back WAV tracks from a CUE sheet alongside the game.

The implementation follows a similar architecture to the SNES core's MSU1 support, with HPS-side streaming into DDRAM and FPGA-side playback, adapted for the MD+ protocol.

The additions are purely additive. Without a CUE file present, the core behaves identically to stock with zero overhead and no extra processing. When a CUE file is present alongside the ROM, the overlay activates and handles playback automatically.

How it works:
- md_plus.sv: intercepts 68K bus writes to the overlay region ($3F7F6–$3FFFF) and decodes play/stop/fade/resume commands
- mdp_audio.sv: reads PCM from a 64KB ring buffer in DDRAM, applies volume and fade, and mixes the output with FM/PSG
- hps_ext.sv: bridges the FPGA and HPS sides via EXT_BUS commands 0x60–0x62
- MegaDrive.sv: has the cart bus mux (MD+ takes priority when the overlay is open), module instantiations, and the audio mixer
- CDDA volume is attenuated to 93/256 (~36.3%), matched to Mega Drive (Japanese model 1, IC BD M5 VA2, 837-6955 motherboard) hardware output via A/B recording comparisons using a MegaSD

Resource impact is minimal. +1% logic, +6 DSP blocks, +1 RAM block. No timing regressions.

Tested with both polling-style type patches (SFII' SCE, SSFII, Golden Axe, Double Dragon etc.) and non-polling patches (Sonic 1, Streets of Rage 2, Mortal Kombat etc.). Zero buffer underruns across all test sessions.

CUE sheet loop points (REM LOOP / REM NOLOOP) follow the established standard used across original hardware implementations such as the MegaSD and the Mega EverDrive PRO/CORE flash cartridges, and emulation platforms such as Genesis Plus GX. Existing MD+ patched ROMs and audio packs work as-is, in that the ROM and CUE filenames must match (e.g. Game.md + Game.cue), with separate WAV files per track. BIN+CUE based audio packs are not supported as they are non-standard for MD+.

Requires a companion PR on Main_MiSTer for the HPS-side CUE parser and WAV streamer.